### PR TITLE
ET-3033: Instance URL Parsing Issue Fix

### DIFF
--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -88,8 +88,7 @@ module SalesforceBulkApi
     end
 
     def parse_instance()
-      @instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}\./).to_s.gsub("https://","").split(".")[0]
-      @instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.nil? || @instance.empty?
+      @instance = @server_url.gsub("https://","").gsub(".salesforce.com", "")
       @instance
     end
 


### PR DESCRIPTION
# Description
Existing parsing logic was causing issue when `@server_url` is something like `https://ab1.my.salesforce.com`
Its parsing `@instance` as `ab1` which is incorrect
We should be getting `ab1.my`